### PR TITLE
Dockerização ✔️

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  hub-ia-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: hub-ia-app
+    ports:
+      - "8501:8501"
+    volumes:
+      - .:/app
+      - ./fecomdb.db:/app/fecomdb.db
+    depends_on:
+      - ollama
+    environment:
+      STREAMLIT_SERVER_HEADLESS: "true"
+      STREAMLIT_SERVER_PORT: "8501"
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/var/lib/ollama
+
+volumes:
+  ollama_data:
+    driver: local

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,16 @@
+tFROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8501
+
+ENV STREAMLIT_SERVER_HEADLESS=true \
+    STREAMLIT_SERVER_PORT=8501
+
+CMD ["streamlit", "run", "app.py", "--server.port=8501", "--server.headless=true"]


### PR DESCRIPTION
## Dockerização

- **Dockerfile**: imagem base `python:3.10-slim`, instala dependências do `requirements.txt`, copia código e expõe a porta **8501** para rodar o Streamlit.

- **docker‑compose.yml**: define dois serviços — `hub-ia-app` (Streamlit) e `ollama` (imagem oficial), com bind mounts para código, banco SQLite e persistência dos dados do Ollama.
